### PR TITLE
Updated version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Tested up to:** 5.2  
 **Requires PHP:** 5.2  
-**Stable tag:** 1.1.1  
+**Stable tag:** 1.2.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -75,6 +75,18 @@ In your WordPress admin dashboard go to Appearance -> Widgets, drag the Astra : 
 3. Navigate to Appearance -> Widgets to access the widgets available from the plugin.
 
 ## Changelog ##
+
+### 1.2.0 ###
+- New: WCAG compatibility.
+- New: Added provision ( using astra_widgets_tel_prefix filter hook ) to remove + sign from telephone link in Address widget.
+- Improvement: Applied Padding right to widgets in case of inline alignment.
+- Fix: Console error for SVG icon in address widget. 
+- Fix: Save button is not working after selecting color from colorpicker.
+- Fix: The official color for the social icon is not working.
+- Fix: The icon is not selected in first attempt in select icon button.
+- Fix: Target option not working for social profiles. 
+- Fix: Skype URL won't work inside social profile widget. 
+- Fix: Color picker not working immediately after widget drop.
 
 ### 1.1.1 ###
 - Fix: PHP Notice while using address widget.

--- a/astra-widgets.php
+++ b/astra-widgets.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Widgets
  * Plugin URI: https://wpastra.com/
  * Description: Astra Widgets
- * Version: 1.1.1
+ * Version: 1.2.0
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Text Domain: astra-widgets
@@ -25,7 +25,7 @@ define( 'ASTRA_WIDGETS_FILE', __FILE__ );
 define( 'ASTRA_WIDGETS_BASE', plugin_basename( ASTRA_WIDGETS_FILE ) );
 define( 'ASTRA_WIDGETS_DIR', plugin_dir_path( ASTRA_WIDGETS_FILE ) );
 define( 'ASTRA_WIDGETS_URI', plugins_url( '/', ASTRA_WIDGETS_FILE ) );
-define( 'ASTRA_WIDGETS_VER', '1.1.1' );
+define( 'ASTRA_WIDGETS_VER', '1.2.0' );
 define( 'ASTRA_WIDGETS_TEMPLATE_DEBUG_MODE', false );
 
 require_once ASTRA_WIDGETS_DIR . 'classes/class-astra-widgets.php';

--- a/classes/class-astra-widgets-helper.php
+++ b/classes/class-astra-widgets-helper.php
@@ -545,7 +545,7 @@ if ( ! class_exists( 'Astra_Widgets_Helper' ) ) :
 
 											<?php
 											$c = '';
-											if ( $option == $value['default'] ) {
+											if ( $option === $value['default'] ) {
 												$c = ' checked="checked" ';
 											}
 											?>
@@ -766,7 +766,7 @@ if ( ! function_exists( 'astra_widgets_parse_css' ) ) {
 				}
 			}
 
-			if ( '' != $parse_css && ( '' !== $min_media || '' !== $max_media ) ) {
+			if ( '' !== $parse_css && ( '' !== $min_media || '' !== $max_media ) ) {
 
 				$media_css       = '@media ';
 				$min_media_css   = '';
@@ -819,7 +819,7 @@ if ( ! function_exists( 'astra_widget_get_css_value' ) ) {
 	 */
 	function astra_widget_get_css_value( $value = '', $unit = 'px', $default = '' ) {
 
-		if ( '' == $value && '' == $default ) {
+		if ( '' === $value && '' === $default ) {
 			return $value;
 		}
 
@@ -829,7 +829,7 @@ if ( ! function_exists( 'astra_widget_get_css_value' ) ) {
 
 			case 'px':
 			case '%':
-						$value   = ( '' != $value ) ? $value : $default;
+						$value   = ( '' !== $value ) ? $value : $default;
 						$css_val = esc_attr( $value ) . $unit;
 				break;
 
@@ -838,8 +838,8 @@ if ( ! function_exists( 'astra_widget_get_css_value' ) ) {
 				break;
 
 			default:
-				$value = ( '' != $value ) ? $value : $default;
-				if ( '' != $value ) {
+				$value = ( '' !== $value ) ? $value : $default;
+				if ( '' !== $value ) {
 					$css_val = esc_attr( $value ) . $unit;
 				}
 		}

--- a/classes/widgets/class-astra-widget-address.php
+++ b/classes/widgets/class-astra-widget-address.php
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Astra_Widget_Address' ) ) :
 								</span>
 							<?php } ?>
 							<?php
-							if( apply_filters( 'astra_widgets_tel_prefix', true ) ) {
+							if ( apply_filters( 'astra_widgets_tel_prefix', true ) ) {
 								$prefix = '+';
 							} else {
 								$prefix = '';
@@ -169,7 +169,7 @@ if ( ! class_exists( 'Astra_Widget_Address' ) ) :
 							add_filter( 'astra_widgets_tel_prefix', '__return_false' );
 							?>
 							<span class="address-meta">
-								<a href="tel:<?php echo $prefix.preg_replace( '/\D/', '', esc_attr( $phone ) ); ?>" ><?php echo esc_attr( $phone ); ?></a>
+								<a href="tel:<?php echo $prefix . preg_replace( '/\D/', '', esc_attr( $phone ) ); ?>" ><?php echo esc_attr( $phone ); ?></a>
 							</span>
 						</div>
 					<?php } ?>

--- a/classes/widgets/class-astra-widget-social-profiles.php
+++ b/classes/widgets/class-astra-widget-social-profiles.php
@@ -350,7 +350,7 @@ if ( ! class_exists( 'Astra_Widget_Social_Profiles' ) ) :
 							$trimmed = str_replace( 'astra-icon-', '', $list['icon'] );
 							?>
 							<li>
-								<a target="<?php echo esc_attr($target); ?>" href="<?php echo esc_attr( $list['link'] ); ?>" target="<?php echo esc_attr( $target ); ?>" rel="<?php echo esc_attr( $rel ); ?>" aria-label="<?php echo ( is_object( $list_data ) ) ? esc_html( $list_data->name ) : ''; ?>">
+								<a target="<?php echo esc_attr( $target ); ?>" href="<?php echo esc_attr( $list['link'] ); ?>" target="<?php echo esc_attr( $target ); ?>" rel="<?php echo esc_attr( $rel ); ?>" aria-label="<?php echo ( is_object( $list_data ) ) ? esc_html( $list_data->name ) : ''; ?>">
 										<span class="ast-widget-icon <?php echo ( is_object( $list_data ) ) ? esc_html( $list_data->name ) : ''; ?>">
 											<?php if ( ! empty( $list_data->viewbox ) && ! empty( $list_data->path ) ) { ?>
 												<svg xmlns="http://www.w3.org/2000/svg" viewBox="<?php echo ( isset( $list_data->viewbox ) ) ? $list_data->viewbox : ''; ?>" width=<?php echo esc_attr( $icon_width ); ?> height=<?php echo esc_attr( $icon_width ); ?> ><path d="<?php echo ( isset( $list_data->path ) ) ? $list_data->path : ''; ?>"></path></svg>

--- a/languages/astra-widgets.pot
+++ b/languages/astra-widgets.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Astra Widgets package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra Widgets 1.1.1\n"
+"Project-Id-Version: Astra Widgets 1.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/astra-widgets\n"
-"POT-Creation-Date: 2019-08-19 06:34:32+00:00\n"
+"POT-Creation-Date: 2019-08-20 09:53:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -46,12 +46,12 @@ msgid "Title:"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-address.php:255
-#: classes/widgets/class-astra-widget-social-profiles.php:482
+#: classes/widgets/class-astra-widget-social-profiles.php:488
 msgid "Inline"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-address.php:256
-#: classes/widgets/class-astra-widget-social-profiles.php:483
+#: classes/widgets/class-astra-widget-social-profiles.php:489
 msgid "Stack"
 msgstr ""
 
@@ -77,14 +77,14 @@ msgstr ""
 
 #: classes/widgets/class-astra-widget-address.php:292
 #: classes/widgets/class-astra-widget-list-icons.php:392
-#: classes/widgets/class-astra-widget-social-profiles.php:502
-#: classes/widgets/class-astra-widget-social-profiles.php:512
+#: classes/widgets/class-astra-widget-social-profiles.php:508
+#: classes/widgets/class-astra-widget-social-profiles.php:518
 msgid "Icon Color"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-address.php:298
 #: classes/widgets/class-astra-widget-list-icons.php:342
-#: classes/widgets/class-astra-widget-social-profiles.php:543
+#: classes/widgets/class-astra-widget-social-profiles.php:549
 msgid "Space Between Icon & Text:"
 msgstr ""
 
@@ -113,27 +113,27 @@ msgid "Link:"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:289
-#: classes/widgets/class-astra-widget-social-profiles.php:440
+#: classes/widgets/class-astra-widget-social-profiles.php:446
 msgid "Same Page"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:290
-#: classes/widgets/class-astra-widget-social-profiles.php:441
+#: classes/widgets/class-astra-widget-social-profiles.php:447
 msgid "New Page"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:296
-#: classes/widgets/class-astra-widget-social-profiles.php:447
+#: classes/widgets/class-astra-widget-social-profiles.php:453
 msgid "No Follow"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:299
-#: classes/widgets/class-astra-widget-social-profiles.php:450
+#: classes/widgets/class-astra-widget-social-profiles.php:456
 msgid "Enable"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:300
-#: classes/widgets/class-astra-widget-social-profiles.php:451
+#: classes/widgets/class-astra-widget-social-profiles.php:457
 msgid "Disable"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgid "Image"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:310
-#: classes/widgets/class-astra-widget-social-profiles.php:457
+#: classes/widgets/class-astra-widget-social-profiles.php:463
 msgid "Icon"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgid "Icon / Image Style"
 msgstr ""
 
 #: classes/widgets/class-astra-widget-list-icons.php:398
-#: classes/widgets/class-astra-widget-social-profiles.php:518
+#: classes/widgets/class-astra-widget-social-profiles.php:524
 msgid "Background Color"
 msgstr ""
 
@@ -220,80 +220,80 @@ msgstr ""
 msgid "Display social profiles."
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:407
-#: classes/widgets/class-astra-widget-social-profiles.php:425
+#: classes/widgets/class-astra-widget-social-profiles.php:413
+#: classes/widgets/class-astra-widget-social-profiles.php:431
 msgid "Title"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:415
+#: classes/widgets/class-astra-widget-social-profiles.php:421
 msgid "Social Profiles"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:420
+#: classes/widgets/class-astra-widget-social-profiles.php:426
 msgid "Add Profile"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:431
+#: classes/widgets/class-astra-widget-social-profiles.php:437
 msgid "Link"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:468
+#: classes/widgets/class-astra-widget-social-profiles.php:474
 msgid "Styling"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:473
+#: classes/widgets/class-astra-widget-social-profiles.php:479
 msgid "Display profile title?"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:479
+#: classes/widgets/class-astra-widget-social-profiles.php:485
 msgid "Alignment"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:489
+#: classes/widgets/class-astra-widget-social-profiles.php:495
 msgid "Icon Style"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:492
+#: classes/widgets/class-astra-widget-social-profiles.php:498
 msgid "Simple"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:493
+#: classes/widgets/class-astra-widget-social-profiles.php:499
 msgid "Circle"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:494
+#: classes/widgets/class-astra-widget-social-profiles.php:500
 msgid "Square"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:495
+#: classes/widgets/class-astra-widget-social-profiles.php:501
 msgid "Circle Outline"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:496
+#: classes/widgets/class-astra-widget-social-profiles.php:502
 msgid "Square Outline"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:505
+#: classes/widgets/class-astra-widget-social-profiles.php:511
 msgid "Official Color"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:506
+#: classes/widgets/class-astra-widget-social-profiles.php:512
 msgid "Custom"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:524
+#: classes/widgets/class-astra-widget-social-profiles.php:530
 msgid "Hover Icon Color"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:530
+#: classes/widgets/class-astra-widget-social-profiles.php:536
 msgid "Hover Background Color"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:536
+#: classes/widgets/class-astra-widget-social-profiles.php:542
 msgid "Icon Width:"
 msgstr ""
 
-#: classes/widgets/class-astra-widget-social-profiles.php:550
+#: classes/widgets/class-astra-widget-social-profiles.php:556
 msgid "\tSpace Between Social Profiles:"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-widgets",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "[![pipeline status](http://git.brainstormforce.com/astra/astra-widgets/badges/master/pipeline.svg)](http://git.brainstormforce.com/astra/astra-widgets/commits/master)",
   "main": "Gruntfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Address widget, Social profile widget, List icon widget, Social media, Add
 Requires at least: 4.7
 Tested up to: 5.2
 Requires PHP: 5.2
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +75,18 @@ In your WordPress admin dashboard go to Appearance -> Widgets, drag the Astra : 
 3. Navigate to Appearance -> Widgets to access the widgets available from the plugin.
 
 == Changelog ==
+
+= 1.2.0 = 
+- New: WCAG compatibility.
+- New: Added provision ( using astra_widgets_tel_prefix filter hook ) to remove + sign from telephone link in Address widget.
+- Improvement: Applied Padding right to widgets in case of inline alignment.
+- Fix: Console error for SVG icon in address widget. 
+- Fix: Save button is not working after selecting color from colorpicker.
+- Fix: The official color for the social icon is not working.
+- Fix: The icon is not selected in first attempt in select icon button.
+- Fix: Target option not working for social profiles. 
+- Fix: Skype URL won't work inside social profile widget. 
+- Fix: Color picker not working immediately after widget drop.
 
 = 1.1.1 =
 - Fix: PHP Notice while using address widget.


### PR DESCRIPTION
- New: WCAG compatibility.
- New: Added provision ( using astra_widgets_tel_prefix filter hook ) to remove + sign from telephone link in Address widget.
- Improvement: Applied Padding right to widgets in case of inline alignment.
- Fix: Console error for SVG icon in address widget. 
- Fix: Save button is not working after selecting color from colorpicker.
- Fix: The official color for the social icon is not working.
- Fix: The icon is not selected in first attempt in select icon button.
- Fix: Target option not working for social profiles. 
- Fix: Skype URL won't work inside social profile widget. 
- Fix: Color picker not working immediately after widget drop.